### PR TITLE
Add copy-to-clipboard button for stored passwords

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -150,9 +150,25 @@
               <div class="secret-card__details">
                 <div v-for="(value, key) in secret.details" :key="key" class="detail-row">
                   <span class="detail-key">{{ prettifyKey(key) }}</span>
-                  <span class="detail-value" :class="{ masked: shouldMask(key) }">
-                    {{ shouldMask(key) ? maskValue(value) : value || '—' }}
-                  </span>
+                  <div class="detail-value-group">
+                    <span class="detail-value" :class="{ masked: shouldMask(key) }">
+                      {{ shouldMask(key) ? maskValue(value) : value || '—' }}
+                    </span>
+                    <button
+                      v-if="shouldMask(key) && value"
+                      type="button"
+                      class="btn subtle copy-btn"
+                      @click="copySecretValue(secret, key, value)"
+                    >
+                      Copy
+                    </button>
+                    <span
+                      v-if="lastCopied.id === secret.id && lastCopied.key === key"
+                      class="copy-feedback"
+                    >
+                      Copied!
+                    </span>
+                  </div>
                 </div>
               </div>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -256,6 +256,7 @@ body {
   justify-content: space-between;
   gap: 1rem;
   font-size: 0.95rem;
+  align-items: center;
 }
 
 .detail-key {
@@ -268,6 +269,23 @@ body {
   color: #e2e8f0;
   max-width: 100%;
   word-break: break-word;
+}
+
+.detail-value-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.copy-btn {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.85rem;
+}
+
+.copy-feedback {
+  font-size: 0.8rem;
+  color: #4ade80;
+  font-weight: 500;
 }
 
 .detail-value.masked {


### PR DESCRIPTION
## Summary
- add copy buttons next to masked secret fields so users can copy values to the clipboard
- track copy state in the Vue app to give quick feedback after a successful copy
- update the secret detail row styling to accommodate the new action button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd931e4190832e85db6b7b1c60a0ab